### PR TITLE
Exclude service failures for fwupd-refresh.service

### DIFF
--- a/scripts_staging/linux_service_check_for_failed.sh
+++ b/scripts_staging/linux_service_check_for_failed.sh
@@ -9,7 +9,7 @@ if [ "${HAS_SYSTEMD}" != 'systemd' ]; then
     exit 0
 fi
 
-failsvc=$(systemctl --failed)
+failsvc=$(systemctl --failed | grep -v 'fwupd-refresh.service')
 
 if [[ "$failsvc" == *"failed"* ]]; then
     echo -e 'You have failed services'
@@ -19,5 +19,3 @@ else
     echo  'All services are running'
     exit 0
 fi
-
-  


### PR DESCRIPTION
In the Linux service check, exclude failures from fwupd-refresh.service.
Noticed this service failing on all of my ubuntu servers that I have, including on one that was setup less than 48 hours ago,
Quick google search confirmed that this one can frequently be shown as failing despite no actual issues.
https://askubuntu.com/a/1405693