### PR TITLE
Report available memory instead of free

### DIFF
--- a/scripts/Linux_memory_check.sh
+++ b/scripts/Linux_memory_check.sh
@@ -19,7 +19,7 @@ then
     min="20"
 fi
 
-MEM_FREE=$(free | grep Mem | awk '{print $4/$2 * 100.0}')
+MEM_FREE=$(free | grep Mem | awk '{print $7/$2 * 100.0}')
 MEM_FREE=$(printf "%.*f\n" "0" "$MEM_FREE")
 
 if [ $MEM_FREE -ge $min ]; 


### PR DESCRIPTION
As pointed out by superdry on Discord, using $4 reports free memory and $7 reports memory available. Available includes buffers/cache that can be freed up and then used for other things without the system having to write to the swap file.

This website explains it quite well: https://www.linuxatemyram.com/