### PR TITLE
Script to check IIS for expiring SSL certs

### DIFF
--- a/scripts_wip/Win_IIS_Check_SSL_Certs.ps1
+++ b/scripts_wip/Win_IIS_Check_SSL_Certs.ps1
@@ -1,0 +1,76 @@
+<#
+.Synopsis
+   Check IIS on Windows Server for Certificates expiring "soon"
+.DESCRIPTION
+   Checks the IIS sites for https bindings and then checks the associated
+   SSL certificate to see if it is expiring "soon".  "Soon" is set to 60 days
+   as the default.
+.EXAMPLE
+   CheckIISCerts
+.INSTRUCTIONS
+   Add this as a script check to your Windows Server that has IIS installed.
+.NOTES
+   Version: 1.0
+   Author: ebdavison (nalantha on discord)
+   Creation Date: 2022-08-08
+#>
+
+Import-Module WebAdministration
+
+$NumDays= 60
+
+$days = (Get-Date).AddDays($NumDays)
+$TxtBindings = (& netsh http show sslcert) | select-object -skip 3 | out-string
+$nl = [System.Environment]::NewLine
+$Txtbindings = $TxtBindings -split "$nl$nl"
+$BindingsList = foreach ($Binding in $Txtbindings) {
+    if ($Binding -ne "") {
+        $Binding = $Binding -replace "  ", "" -split ": "
+        [pscustomobject]@{
+            IPPort          = ($Binding[1] -split "`n")[0]
+            CertificateHash = ($Binding[2] -split "`n" -replace '[^a-zA-Z0-9]', '')[0]
+            AppID           = ($Binding[3] -split "`n")[0]
+            CertStore       = ($Binding[4] -split "`n")[0]
+        }
+    }
+}
+
+if ($BindingsList.Count -eq 0) {
+    $CertState = "Healthy - No certificate bindings found."
+    Write-Output $CertState
+    exit 0
+}
+
+$CertState = foreach ($bind in $bindingslist) {
+
+    $bindsite = $bind.ipport.Split(":")[0]
+    
+    $CertFileWH = Get-ChildItem -path "CERT:LocalMachine\WebHosting" | Where-Object -Property ThumbPrint -eq $bind.CertificateHash
+
+    $CertFileMY = Get-ChildItem -path "CERT:LocalMachine\MY" | Where-Object -Property ThumbPrint -eq $bind.CertificateHash
+
+    if ($bindsite -eq "0.0.0.0") {
+        continue
+    }
+    
+    if ($certFileWH.NotAfter) {
+        if ($certFileWH.NotAfter -lt $Days) { 
+            "$($bindsite) = $($certfileWH.FriendlyName) / $($certfileWH.thumbprint) will expire on $($certfileWH.NotAfter)" 
+        }
+    }
+
+    if ($certFileMY.NotAfter) {
+        if ($certFileMY.NotAfter -lt $Days) { 
+            "$($bindsite) = $($certfileMY.FriendlyName) / $($certfileMY.thumbprint) will expire on $($certfileWMY.NotAfter)" 
+        }
+    }
+}
+
+if (!$certState){
+    $CertState = "Healthy - No Expiring Certificates"; 
+    Write-Output $CertState
+    exit 0
+} else {
+    Write-Output $CertState
+    exit 1
+}


### PR DESCRIPTION
Check the bindings for all IIS sites and find the matching SSL certs.  Check to see if the cert is set to expire within 60 days (current default in script) and alert if any will expire.