### PR TITLE
Add online disk check / repair script (powershell)

### DIFF
--- a/community_scripts.json
+++ b/community_scripts.json
@@ -1638,5 +1638,22 @@
     "supported_platforms": ["windows"],
     "shell": "powershell",
     "category": "TRMM (Win):3rd Party Software"
+  },
+  {
+    "guid": "2953cafc-3bae-4717-88da-ddeb4b14eb9b",
+    "filename": "Win_Disk_Check_Repair.ps1",
+    "submittedBy": "https://github.com/lcsnetworks",
+    "name": "Disk - Check / Repair",
+    "description": "Check and optionally repair disk volume on the target system/drive",
+    "syntax": "[-driveletter <string>]\n[-spotfix]\n[-offline]",
+    "args": [
+      "-driveletter C"
+    ],
+    "default_timeout": "3600",
+    "shell": "powershell",
+    "supported_platforms": [
+      "windows"
+    ],
+    "category": "TRMM (Win):Hardware"
   }
 ]

--- a/scripts/Win_Disk_Check_Repair.ps1
+++ b/scripts/Win_Disk_Check_Repair.ps1
@@ -17,17 +17,17 @@
     When specified, the script performs a spot fix on the volume.
 
 .EXAMPLE
-    .\RepairVolume.ps1 -DriveLetter "C"
+    -DriveLetter "C"
 
     Performs an online scan of the volume with the drive letter "C"
 
 .EXAMPLE
-    .\RepairVolume.ps1 -DriveLetter "C" -Offline
+    -DriveLetter "C" -Offline
 
     Schedules an offline scan of the volume with the drive letter "C" upon next reboot
 
 .EXAMPLE
-    .\RepairVolume.ps1 -DriveLetter "C" -SpotFix
+    -DriveLetter "C" -SpotFix
 
     Performs a spot fix on the volume with the drive letter "C"
 #>

--- a/scripts/Win_Disk_Check_Repair.ps1
+++ b/scripts/Win_Disk_Check_Repair.ps1
@@ -43,14 +43,14 @@ param(
 
 # Perform the requested operation(s) on the volume
 if ($Offline) {
-    Write-Host "Performing offline scan on volume $DriveLetter`:"
+    Write-Output "Performing offline scan on volume $DriveLetter`:"
     Repair-Volume -DriveLetter $DriveLetter -OfflineScanAndFix
 }
 elseif ($SpotFix) {
-    Write-Host "Performing spot fix on volume $DriveLetter`:"
+    Write-Output "Performing spot fix on volume $DriveLetter`:"
     Repair-Volume -DriveLetter $DriveLetter -SpotFix
 }
 else {
-    Write-Host "Performing online scan on volume $DriveLetter`:"
+    Write-Output "Performing online scan on volume $DriveLetter`:"
     Repair-Volume -DriveLetter $DriveLetter -Scan
 }

--- a/scripts/Win_Disk_Check_Repair.ps1
+++ b/scripts/Win_Disk_Check_Repair.ps1
@@ -1,0 +1,56 @@
+<#
+.SYNOPSIS
+    A PowerShell script to repair a volume using the Repair-Volume cmdlet.
+
+.DESCRIPTION
+    This script uses the Repair-Volume cmdlet to scan and/or repair a specified volume
+    based on the provided DriveLetter. By default, the script performs an online scan.
+    The user can choose to perform an offline scan or a spot fix on the volume.
+
+.PARAMETER DriveLetter
+    Specifies the drive letter of the volume to be scanned/repaired.
+
+.PARAMETER Offline
+    When specified, the script performs an offline scan on the volume.
+
+.PARAMETER SpotFix
+    When specified, the script performs a spot fix on the volume.
+
+.EXAMPLE
+    .\RepairVolume.ps1 -DriveLetter "C"
+
+    Performs an online scan of the volume with the drive letter "C"
+
+.EXAMPLE
+    .\RepairVolume.ps1 -DriveLetter "C" -Offline
+
+    Schedules an offline scan of the volume with the drive letter "C" upon next reboot
+
+.EXAMPLE
+    .\RepairVolume.ps1 -DriveLetter "C" -SpotFix
+
+    Performs a spot fix on the volume with the drive letter "C"
+#>
+
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$DriveLetter,
+
+    [switch]$Offline,
+    [switch]$SpotFix
+)
+
+# Perform the requested operation(s) on the volume
+if ($Offline) {
+    Write-Host "Performing offline scan on volume $DriveLetter`:"
+    Repair-Volume -DriveLetter $DriveLetter -OfflineScanAndFix
+}
+elseif ($SpotFix) {
+    Write-Host "Performing spot fix on volume $DriveLetter`:"
+    Repair-Volume -DriveLetter $DriveLetter -SpotFix
+}
+else {
+    Write-Host "Performing online scan on volume $DriveLetter`:"
+    Repair-Volume -DriveLetter $DriveLetter -Scan
+}


### PR DESCRIPTION
This PR adds an online disk repair using PowerShell. By default, it runs a simple online check for volume errors. Optionally, you can include the `spotfix` parameter to attempt to repair the volume while it is mounted, or you can schedule an `offline` scan on the next reboot.