### PR TITLE
Fixed a bug with secure-string conversion

### DIFF
--- a/scripts/Win_AD_Join_Computer.ps1
+++ b/scripts/Win_AD_Join_Computer.ps1
@@ -30,6 +30,7 @@
     V1.0 Initial release 6/19/2021 rfost52
     V1.1 Parameterization; Error Checking with conditionals and exit codes
     V1.2 Variable declarations cleaned up; minor syntax corrections; Output to file added (@jeevis)
+    V1.3 Fixed error with string to secure-string convertion; Added information for escaping $ character (@jxd-decision)
 
     Reference Links: 
     www.google.com
@@ -41,7 +42,7 @@ param (
     [ValidateNotNullOrEmpty()]
     [string]$Domain,
 
-    [Parameter(Mandatory = $true, HelpMessage = "The password for the domain account.")]
+    [Parameter(Mandatory = $true, HelpMessage = "The password for the domain account. If the password contains a '$' you have to escape it with a single backtick '``'")]
     [ValidateNotNullOrEmpty()]
     [string]$Password,
 
@@ -72,8 +73,8 @@ if ([string]::IsNullOrEmpty($password)) {
 
 else {
     $username = "$domain\$UserAccount"
-    $password = ConvertTo-SecureString -string $password -asPlainText -Force
-    $credential = New-Object System.Management.Automation.PSCredential($username, $password)
+    $securePassword = ConvertTo-SecureString -string $password -asPlainText -Force
+    $credential = New-Object System.Management.Automation.PSCredential($username, $securePassword)
 }
 
 try {


### PR DESCRIPTION
Background: [Had issues joining our AD and reached out to free-support ](https://discord.com/channels/736478043522072608/1107671030115340378)

While investigating the problem I came across [this StackOverflow post](https://stackoverflow.com/a/23004997)

Did some testing and encountered a "credentials not correct" error. But this time the script actually created the log file and I could verify the script was doing something. After some more investigation I found out that my password contained a "$" which had to be escaped. I dont know if its wanted or necessary but I added a little hint that "$" characters have to be escaped.