### PR TITLE
Use Docker to develop Python and PowerShell scripts

### DIFF
--- a/Dockerfile-python
+++ b/Dockerfile-python
@@ -1,0 +1,27 @@
+# https://hub.docker.com/_/python
+# https://stackoverflow.com/questions/48561981/activate-python-virtualenv-in-dockerfile
+
+# First stage is the builder or compiler
+FROM python:3.8-slim as compiler
+ENV PYTHONUNBUFFERED 1
+
+WORKDIR /app
+
+RUN python -m venv /opt/venv
+# Enable venv
+ENV PATH="/opt/venv/bin:$PATH"
+
+COPY ./requirements.txt /app/requirements.txt
+RUN pip install --no-cache-dir --upgrade --requirement requirements.txt
+
+# First stage is the runner
+FROM python:3.8-slim as runner
+WORKDIR /app
+COPY --from=compiler /opt/venv /opt/venv
+
+# Enable venv
+ENV PATH="/opt/venv/bin:$PATH"
+COPY . /app/
+# This is used instead of 'entrypoint' in docker-compose.yml.
+# Note: The stackoverflow answers state virtualenv is not needed most of the time.
+CMD ["/bin/bash" ]

--- a/README.md
+++ b/README.md
@@ -33,3 +33,18 @@ pip install -r requirements.txt
 ```
 pytest
 ```
+
+## Develop using Docker
+
+Download and install [Task][] into your path (or current directory). Run `task --list` to list available tasks. Run `task <task-name> --summary` to generate a summary of the commands Task will run. Run `task dev-python` to develop Python scripts in Docker. Run `task dev-powershell` to develop PowerShell scripts in Docker.
+
+```text
+$ task --list
+task: Available tasks for this project:
+* dev-powershell:                   Use Docker compose for development of PowerShell scripts
+* dev-python:                       Build and run Python in Docker to develop Python scripts
+* dev-python-build:                 Build the Docker image to develop Python scripts
+* dev-python-compose-run:           Use Docker compose for development of Python scripts
+```
+
+[Task]: https://github.com/go-task/task/releases

--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ pytest
 
 Download and install [Task][] into your path (or current directory). Run `task --list` to list available tasks. Run `task <task-name> --summary` to generate a summary of the commands Task will run. Run `task dev-python` to develop Python scripts in Docker. Run `task dev-powershell` to develop PowerShell scripts in Docker.
 
+> Note: The `--interactive` flag was introduced in [Docker compose version v2.3.0][].
+
 ```text
 $ task --list
 task: Available tasks for this project:
@@ -48,3 +50,5 @@ task: Available tasks for this project:
 ```
 
 [Task]: https://github.com/go-task/task/releases
+
+[Docker version v2.3.0]: https://github.com/docker/compose/releases/tag/v2.3.0

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -63,7 +63,7 @@ tasks:
           docker compose \
             --project-name '{{.PROJECT_NAME}}' \
             --file '{{.COMPOSE_FILE}}' \
-            run --interactive '{{.SERVICE_NAME}}'
+            run --interactive --rm '{{.SERVICE_NAME}}'
 
   dev-python-build:
     desc: Build the Docker image to develop Python scripts
@@ -121,4 +121,4 @@ tasks:
           docker compose \
             --project-name '{{.PROJECT_NAME}}' \
             --file '{{.COMPOSE_FILE}}' \
-            run --interactive '{{.SERVICE_NAME}}'
+            run --interactive --rm '{{.SERVICE_NAME}}'

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -1,0 +1,108 @@
+---
+version: 3
+
+tasks:
+
+  donothing: 'true'
+
+  list:
+    cmds:
+      - cmd: 'task --list'
+
+  dev-python:
+    desc: Build and run Python in Docker to develop Python scripts
+    summary: |
+      Build a Python image and run it to develop in Python using Docker.
+    vars:
+      DOCKERFILE: 'Dockerfile-python'
+      COMPOSE_FILE: 'docker-compose-python.yml'
+      CONTAINER_NAME: 'python/3.8'
+      PROJECT_NAME: 'community-scripts-python'
+      SERVICE_NAME: 'python'
+    preconditions:
+      - sh: docker version
+        msg: |
+          'docker build' is required to run build the docker image.
+          Please install 'docker' or Docker Desktop and try again.
+          See: https://docs.docker.com/desktop/
+          Note: This may use 'docker buildx' in the future.
+      - sh: docker compose --version
+        msg: |
+          'docker compose' (version 2, a.k.a. plugin) is required to run the docker compose file.
+          Please install 'docker compose' and try again.
+          See: https://docs.docker.com/compose/install/
+    cmds:
+      - task: dev-python-build
+        vars:
+          DOCKERFILE: '{{.DOCKERFILE}}'
+          CONTAINER_NAME: '{{.CONTAINER_NAME}}'
+      - task: dev-python-compose-run
+        vars:
+          COMPOSE_FILE: '{{.COMPOSE_FILE}}'
+          CONTAINER_NAME: '{{.CONTAINER_NAME}}'
+          PROJECT_NAME: '{{.PROJECT_NAME}}'
+          SERVICE_NAME: '{{.SERVICE_NAME}}'
+
+  dev-python-compose-run:
+    desc: Use Docker compose for development of Python scripts
+    summary: |
+      Use Docker compose to start a Python image for development of Python scripts
+    vars:
+      COMPOSE_FILE: '{{.COMPOSE_FILE | default "docker-compose-python.yml"}}'
+      CONTAINER_NAME: '{{.CONTAINER_NAME | default "python/3.8"}}'
+      SERVICE_NAME: '{{.SERVICE_NAME | default "python"}}'
+      PROJECT_NAME: '{{.PROJECT_NAME | default "community-scripts-python"}}'
+    preconditions:
+      - sh: docker compose --version
+        msg: |
+          'docker compose' (version 2, a.k.a. plugin) is required to run the docker compose file.
+          Please install 'docker compose' and try again.
+          See: https://docs.docker.com/compose/install/
+    cmds:
+      - cmd: |
+          docker compose \
+            --project-name "{{.PROJECT_NAME}}" \
+            --file '{{.COMPOSE_FILE}}' \
+            run --interactive '{{.SERVICE_NAME}}'
+
+  dev-python-build:
+    desc: Build the Docker image to develop Python scripts
+    summary: |
+      Build a Python image to support development of Python scripts.
+    vars:
+      DOCKERFILE: '{{.DOCKERFILE | default "Dockerfile-python"}}'
+      CONTAINER_NAME: '{{.CONTAINER_NAME | default "python/3.8"}}'
+    preconditions:
+      - sh: docker version
+        msg: |
+          'docker build' is required to run build the docker image.
+          Please install 'docker' or Docker Desktop and try again.
+          See: https://docs.docker.com/desktop/
+          Note: This may use 'docker buildx' in the future.
+    cmds:
+      - cmd: |
+          docker build \
+            --tag "{{.CONTAINER_NAME}}" \
+            --file "{{.DOCKERFILE}}" \
+            .
+
+  dev-powershell:
+    desc: Use Docker compose for development of PowerShell scripts
+    summary: |
+      Use Docker compose to start a PowerShell image for development of PowerShell scripts
+    vars:
+      COMPOSE_FILE: '{{.COMPOSE_FILE | default "docker-compose-powershell.yml"}}'
+      SERVICE_NAME: '{{.SERVICE_NAME | default "powershell"}}'
+      PROJECT_NAME: '{{.PROJECT_NAME | default "community-scripts-powershell"}}'
+    preconditions:
+      - sh: docker compose --version
+        msg: |
+          'docker compose' (version 2, a.k.a. plugin) is required to run the docker compose file.
+          Please install 'docker compose' and try again.
+          See: https://docs.docker.com/compose/install/
+    cmds:
+      - cmd: |
+          docker compose \
+            --project-name "{{.PROJECT_NAME}}" \
+            --file '{{.COMPOSE_FILE}}' \
+            run --interactive '{{.SERVICE_NAME}}'

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -61,7 +61,7 @@ tasks:
     cmds:
       - cmd: |
           docker compose \
-            --project-name "{{.PROJECT_NAME}}" \
+            --project-name '{{.PROJECT_NAME}}' \
             --file '{{.COMPOSE_FILE}}' \
             run --interactive '{{.SERVICE_NAME}}'
 
@@ -82,14 +82,30 @@ tasks:
     cmds:
       - cmd: |
           docker build \
-            --tag "{{.CONTAINER_NAME}}" \
-            --file "{{.DOCKERFILE}}" \
+            --tag '{{.CONTAINER_NAME}}' \
+            --file '{{.DOCKERFILE}}' \
             .
 
   dev-powershell:
     desc: Use Docker compose for development of PowerShell scripts
     summary: |
       Use Docker compose to start a PowerShell image for development of PowerShell scripts
+    env:
+      # ARM64 on macOS is supported by running the ARM64 image for Linux.
+      # Part of the problem is that ARM in QEMU is not supported.
+      # See https://github.com/PowerShell/PowerShell-Docker/wiki/Known-Issues#arm-and-qemu-not-supported
+      # In the GitHub issues, arm32v7-ubuntu-bionic was mentioned but all ARM32 images are End of Life.
+      # The ARM64 image is mariner-2.0-arm64.
+      # This environment variable is passed to the docker-compose-powershell.yml file to specify the image tag.
+      MACOS_ARM64:
+        sh: |
+          {{ if eq OS "darwin" }}
+            if [[ "$(uname -m)" == "arm64" ]]; then
+              echo ":mariner-2.0-arm64"
+            fi
+          {{ else }}
+            echo ""
+          {{ end }}
     vars:
       COMPOSE_FILE: '{{.COMPOSE_FILE | default "docker-compose-powershell.yml"}}'
       SERVICE_NAME: '{{.SERVICE_NAME | default "powershell"}}'
@@ -103,6 +119,6 @@ tasks:
     cmds:
       - cmd: |
           docker compose \
-            --project-name "{{.PROJECT_NAME}}" \
+            --project-name '{{.PROJECT_NAME}}' \
             --file '{{.COMPOSE_FILE}}' \
             run --interactive '{{.SERVICE_NAME}}'

--- a/docker-compose-powershell.yml
+++ b/docker-compose-powershell.yml
@@ -12,4 +12,5 @@ services:
     working_dir: /community-scripts
     volumes:
       # Mount the repo in Docker
-      - ${PWD}:/community-scripts
+      # Note: ${PWD} is not available on Windows
+      - .:/community-scripts

--- a/docker-compose-powershell.yml
+++ b/docker-compose-powershell.yml
@@ -4,7 +4,7 @@ version: '3.7'
 services:
 
   powershell:
-    image: mcr.microsoft.com/powershell
+    image: "mcr.microsoft.com/powershell${MACOS_ARM64}"
     environment:
       - POWERSHELL_TELEMETRY_OPTOUT=1
     stdin_open: true    # docker run -i

--- a/docker-compose-powershell.yml
+++ b/docker-compose-powershell.yml
@@ -1,0 +1,15 @@
+---
+version: '3.7'
+
+services:
+
+  powershell:
+    image: mcr.microsoft.com/powershell
+    environment:
+      - POWERSHELL_TELEMETRY_OPTOUT=1
+    stdin_open: true    # docker run -i
+    tty: true           # docker run -t
+    working_dir: /community-scripts
+    volumes:
+      # Mount the repo in Docker
+      - ${PWD}:/community-scripts

--- a/docker-compose-python.yml
+++ b/docker-compose-python.yml
@@ -12,4 +12,5 @@ services:
     working_dir: /community-scripts
     volumes:
       # Mount the repo in Docker
-      - ${PWD}:/community-scripts
+      # Note: ${PWD} is not available on Windows
+      - .:/community-scripts

--- a/docker-compose-python.yml
+++ b/docker-compose-python.yml
@@ -1,0 +1,15 @@
+---
+version: '3.7'
+
+services:
+
+  python:
+    image: python/3.8
+    stdin_open: true    # docker run -i
+    tty: true           # docker run -t
+    # Dockerfile CMD runs bash. This is here for future reference.
+    # entrypoint: /bin/bash
+    working_dir: /community-scripts
+    volumes:
+      # Mount the repo in Docker
+      - ${PWD}:/community-scripts


### PR DESCRIPTION
This PR requires [Task][] and Docker. Running `task dev-python` will start a Docker container with Python 3.8. Running `task dev-powershell` will start a Docker container with the latest PowerShell (`pwsh`). This has been tested on Linux (openSUSE), macOS (M1 Ventura) and Windows 11.

If there are problems with running Docker, make sure you have the latest version of Docker Desktop or the `docker compose` plugin.

[Task]: https://github.com/go-task/task