### PR TITLE
Scripts to monitor HP Proliant hardware status

### DIFF
--- a/nix_bash_HP_CPU_Status.sh
+++ b/nix_bash_HP_CPU_Status.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+#Get Server/CPU status
+RESULT=$(hpasmcli -s "show server" | grep -i status)
+RETURN=0
+#Loop through each CPU and fail if any is not OK
+while IFS= read -r line; do
+    echo "$line"
+	if [[ $line == *"Status       : Ok"* ]]; 
+	then echo "Good"; 
+	else echo "Bad"; RETURN=1; 
+	fi
+done <<< "$RESULT"
+echo $RETURN
+#Return result to TRMM
+if [ $RETURN == 0 ]; then
+	echo "CPUs are Healthy"
+	#exit 0
+else 
+	echo "CPU Fault"
+	#exit 2
+fi

--- a/nix_bash_HP_Memory_Status.sh
+++ b/nix_bash_HP_Memory_Status.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+#Get DIMM status
+RESULT=$(hpasmcli -s "show dimm" | grep -i status)
+RETURN=0
+#Loop through each DIMM and fail if any is not OK
+while IFS= read -r line; do
+    echo "$line"
+	if [[ $line == *"Status:                       Ok"* ]]; 
+	then echo "Good"; 
+	else echo "Bad"; RETURN=1; 
+	fi
+done <<< "$RESULT"
+echo $RETURN
+#Return result to TRMM
+if [ $RETURN == 0 ]; then
+	echo "Memory Modules are Healthy"
+	exit 0
+else 
+	echo "Memory Fault"
+	exit 2
+fi

--- a/nix_bash_HP_Power_Supply_Status.sh
+++ b/nix_bash_HP_Power_Supply_Status.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+#Get DIMM status
+RESULT=$(hpasmcli -s "show powersupply" | grep -i condition)
+RETURN=0
+#Loop through each DIMM and fail if any is not OK
+while IFS= read -r line; do
+    echo "$line"
+	if [[ $line == *"Condition: Ok"* ]]; 
+	then echo "Good"; 
+	else echo "Bad"; RETURN=1; 
+	fi
+done <<< "$RESULT"
+echo $RETURN
+#Return result to TRMM
+if [ $RETURN == 0 ]; then
+	echo "Power Supplies are Healthy"
+	exit 0
+else 
+	echo "Power Supply Fault"
+	exit 2
+fi

--- a/nix_bash_HP_RAID_Battery_Status.sh
+++ b/nix_bash_HP_RAID_Battery_Status.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+CONTROLLER=$(hpssacli ctrl all show status | grep -i battery)
+echo $CONTROLLER
+if [[ $CONTROLLER == *"Battery/Capacitor Status: OK"* ]]; then
+  echo "RAID Battery is Healthy"
+  exit 0
+else
+  echo "RAID Battery has Error"
+  exit 2
+fi

--- a/nix_bash_HP_RAID_Cache_Status.sh
+++ b/nix_bash_HP_RAID_Cache_Status.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+CONTROLLER=$(hpssacli ctrl all show status | grep -i cache)
+echo $CONTROLLER
+if [[ $CONTROLLER == *"Cache Status: OK"* ]]; then
+  echo "RAID Cache is Healthy"
+  exit 0
+else
+  echo "RAID Cache has Error"
+  exit 2
+fi

--- a/nix_bash_HP_RAID_Controller_Status.sh
+++ b/nix_bash_HP_RAID_Controller_Status.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+CONTROLLER=$(hpssacli ctrl all show status | grep -i controller)
+echo $CONTROLLER
+if [[ $CONTROLLER == *"Controller Status: OK"* ]]; then
+  echo "RAID Controller is Healthy"
+  exit 0
+else
+  echo "RAID Controller has Error"
+  exit 2
+fi

--- a/nix_bash_Install_HP_Server_Health_Tools.sh
+++ b/nix_bash_Install_HP_Server_Health_Tools.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+cd /tmp
+wget https://downloads.linux.hpe.com/SDR/repo/mcp/centos/6/x86_64/10.40/hpssacli-2.40-13.0.x86_64.rpm
+yum install -y --nogpgcheck hpssacli-2.40-13.0.x86_64.rpm
+wget https://downloads.linux.hpe.com/SDR/repo/mcp/centos/6/x86_64/10.40/hp-health-10.40-1777.17.rhel6.x86_64.rpm
+yum install -y --nogpgcheck hp-health-10.40-1777.17.rhel6.x86_64.rpm


### PR DESCRIPTION
1 script downloads and installs 2 official HP tools from their website (RPM/Yum only at this time) 6 scripts that can be used for script checks for various bits of hardware; Return code 2 for errors. Tested on XCP-NG on an 8th Gen HP ProLiant rack server.