### PR TITLE
Add mode upgrade-only-installed to Win_Chocolatey_Manage_Apps_Bulk.ps1

### DIFF
--- a/community_scripts.json
+++ b/community_scripts.json
@@ -903,8 +903,8 @@
     "filename": "Win_Chocolatey_Manage_Apps_Bulk.ps1",
     "submittedBy": "https://github.com/silversword411",
     "name": "Chocolatey - Install, Uninstall, List and Upgrade Software",
-    "description": "This script installs, uninstalls and updates software using Chocolatey with logic to slow tasks to minimize hitting community limits. Mode install/uninstall/upgrade Hosts x",
-    "syntax": "-PackageName <string>\n[-Hosts <string>]\n[-mode {(install) | upgrade | uninstall | list}]",
+    "description": "This script installs, uninstalls and updates software using Chocolatey with logic to slow tasks to minimize hitting community limits. Mode install/uninstall/upgrade/upgrade-only-installed Hosts x",
+    "syntax": "-PackageName <string>\n[-Hosts <string>]\n[-mode {(install) | upgrade | upgrade-only-installed | uninstall | list}]",
     "shell": "powershell",
     "category": "TRMM (Win):3rd Party Software>Chocolatey",
     "supported_platforms": [

--- a/scripts/Win_Chocolatey_Manage_Apps_Bulk.ps1
+++ b/scripts/Win_Chocolatey_Manage_Apps_Bulk.ps1
@@ -6,7 +6,12 @@
     This script uses Chocolatey to manage software packages. It introduces rate limiting when run on multiple hosts to avoid hitting rate limits at chocolatey.org. Use the Hosts parameter to specify the number of computers the script is running on.
 
     .PARAMETER Mode
-    4 modes: 'install' (default), 'uninstall', 'upgrade', or 'list'.
+    5 modes: 'install' (default), 'uninstall', 'upgrade', 'upgrade-only-installed' or 'list'.
+    Mode 'install' installs the software specified by "PackageName"
+    Mode 'uninstall' removes the software specified by "PackageName"
+    Mode 'upgrade' checks for newer version and upgrades the package(s). If package is not existing on system it gets installed (default behaviour of chocolatey). You can specify multiple one or more packages seperated by comma. If no PackageName is given all installed packages are being updated
+    Mode 'upgrade-only-installed' checks for newer version of the package(s) and upgrades it. It will _not_ install new software (by adding --failonnotinstalled to the choco-command).
+    Mode 'list' lists packages which are installed by chocolatey on the target
 
     .PARAMETER Hosts
     Use this to specify the number of computer(s) you're running the command on. This will dynamically introduce waits to try and minimize the chance of hitting rate limits (20/min) on the chocolatey.org site: Hosts 20
@@ -21,12 +26,16 @@
     -Mode upgrade -Hosts 50 -PackageName chocolatey
 
     .EXAMPLE
+    -Mode upgrade-only-installed -Hosts 20 -PackageName googlechrome,firefox
+
+    .EXAMPLE
     -Mode list
 
     .NOTES
     9/2021 v1 Initial release by @silversword411 and @bradhawkins 
     11/14/2021 v1.1 Fixing typos and logic flow
     12/8/2023 v1.3 Adding list, making choco full path
+    2/22/2024 v1.4 Adding 'upgrade-only-installed' as mode by @derfladi
 #>
 
 param (
@@ -37,7 +46,7 @@ param (
     [string[]] $PackageName,
 
     [Parameter(Mandatory = $false)]
-    [ValidateSet("install", "uninstall", "upgrade", "list")]
+    [ValidateSet("install", "uninstall", "upgrade", "upgrade-only-installed", "list")]
     [string] $Mode = "install"
 )
 
@@ -50,7 +59,7 @@ if (-not (Test-Path $chocoExePath)) {
 
 $ErrorCount = 0
 
-if ($Mode -ne "upgrade" -and $Mode -ne "list" -and -not $PackageName) {
+if ($Mode -ne "upgrade" -and $Mode -ne "upgrade-only-installed" -and $Mode -ne "list" -and -not $PackageName) {
     Write-Output "Error: No package name provided. Please specify a package name, e.g., `-PackageName googlechrome`."
     Exit 1
 }
@@ -84,6 +93,16 @@ switch ($Mode) {
         }
         else {
             & $chocoExePath upgrade all -y
+        }
+    }
+    "upgrade-only-installed" {
+        if ($PackageName) {
+            foreach ($package in $PackageName) {
+                & $chocoExePath upgrade $package --failonnotinstalled -y
+            }
+        }
+        else {
+            & $chocoExePath upgrade all --failonnotinstalled -y
         }
     }
     "list" {

--- a/scripts/Win_Chocolatey_Manage_Apps_Bulk.ps1
+++ b/scripts/Win_Chocolatey_Manage_Apps_Bulk.ps1
@@ -9,7 +9,7 @@
     5 modes: 'install' (default), 'uninstall', 'upgrade', 'upgrade-only-installed' or 'list'.
     Mode 'install' installs the software specified by "PackageName"
     Mode 'uninstall' removes the software specified by "PackageName"
-    Mode 'upgrade' checks for newer version and upgrades the package(s). If package is not existing on system it gets installed (default behaviour of chocolatey). You can specify multiple one or more packages seperated by comma. If no PackageName is given all installed packages are being updated
+    Mode 'upgrade' checks for newer version and upgrades the package(s). If package is not existing on system it gets installed (default behaviour of chocolatey). If no PackageName is given all installed packages are being updated.
     Mode 'upgrade-only-installed' checks for newer version of the package(s) and upgrades it. It will _not_ install new software (by adding --failonnotinstalled to the choco-command).
     Mode 'list' lists packages which are installed by chocolatey on the target
 


### PR DESCRIPTION
Adding mode parameter "upgrade-only-installed" to force chocolatey to upgrade only packages which are installed. Default behaviour of chocolatey would be to install packages which are not found on the target although we only want to upgrade (see https://docs.chocolatey.org/en-us/choco/commands/upgrade)