### PR TITLE
Remove hardcoded path to choco.exe and use %ChocolateyInstall% / $env:ChocolateyInstall env variable to find it.

### DIFF
--- a/scripts/Win_Chocolatey_List_Installed.bat
+++ b/scripts/Win_Chocolatey_List_Installed.bat
@@ -1,2 +1,2 @@
 rem List packages installed by Chocolatey
-%ChocolateyInstall%\choco.exe list
+%ChocolateyInstall%\bin\choco.exe list

--- a/scripts/Win_Chocolatey_List_Installed.bat
+++ b/scripts/Win_Chocolatey_List_Installed.bat
@@ -1,5 +1,2 @@
-rem List apps installed by Chocolatey
-
-set "chocoExePath=%PROGRAMDATA%\chocolatey\choco.exe"
-
-"%chocoExePath%" list
+rem List packages installed by Chocolatey
+%ChocolateyInstall%\choco.exe list

--- a/scripts/Win_Chocolatey_Manage_Apps_Bulk.ps1
+++ b/scripts/Win_Chocolatey_Manage_Apps_Bulk.ps1
@@ -51,7 +51,7 @@ param (
     [string] $Mode = "install"
 )
 
-$chocoExePath = "$env:PROGRAMDATA\chocolatey\choco.exe"
+$chocoExePath = "$env:ChocolateyInstall\choco.exe"
 
 if (-not (Test-Path $chocoExePath)) {
     Write-Output "Chocolatey is not installed."

--- a/scripts/Win_Chocolatey_Manage_Apps_Bulk.ps1
+++ b/scripts/Win_Chocolatey_Manage_Apps_Bulk.ps1
@@ -51,7 +51,7 @@ param (
     [string] $Mode = "install"
 )
 
-$chocoExePath = "$env:ChocolateyInstall\choco.exe"
+$chocoExePath = "$env:ChocolateyInstall\bin\choco.exe"
 
 if (-not (Test-Path $chocoExePath)) {
     Write-Output "Chocolatey is not installed."


### PR DESCRIPTION
It should not be assumed that Chocolatey choco.exe is found in c:\programdata\chocolatey as it can be installed elsewhere.

Upon install, Chocolatey sets a system environmental variable pointing to where it was installed, this is %ChocolateyInstall%/$env:ChocolateyInstall and that environmental variable is best practice to find the location of choco.exe. v0.98(?) and before used c:\chocolatey

Also, Chocolatey doesn't install apps, it installs packages which in turn are most likely programs.