### PR TITLE
Remove a deprecated script

### DIFF
--- a/community_scripts.json
+++ b/community_scripts.json
@@ -457,18 +457,6 @@
     "category": "TRMM (Win):Collectors"
   },
   {
-    "guid": "3e9881a1-5860-4a4e-9e34-e2a091381da6",
-    "filename": "zzDEPRECATED_Win_RustDesk_GetID.ps1",
-    "submittedBy": "https://github.com/dinger1986/",
-    "name": "RustDesk - Get RustDeskID for client",
-    "description": "Script doesn't work and won't be updated please obtain up to date scripts from https://docs.tacticalrmm.com/3rdparty_rustdesk/",
-    "shell": "powershell",
-    "supported_platforms": [
-      "windows"
-    ],
-    "category": "DEPRECATED"
-  },
-  {
     "guid": "95a2ee6f-b89b-4551-856e-3081b041caa7",
     "filename": "Win_Power_Profile_Reset_High_Performance_to_Defaults.ps1",
     "submittedBy": "https://github.com/azulskyknight",

--- a/scripts/zzDEPRECATED_Win_RustDesk_GetID.ps1
+++ b/scripts/zzDEPRECATED_Win_RustDesk_GetID.ps1
@@ -1,7 +1,0 @@
-# No Longer working please use from https://docs.tacticalrmm.com/3rdparty_rustdesk/
-$ErrorActionPreference = 'silentlycontinue'
-
-Write-output ".............................................................................................................................."
-Write-output "Script doesn't work and won't be updated please obtain up to date scripts from https://docs.tacticalrmm.com/3rdparty_rustdesk/"
-Write-output ".............................................................................................................................."
-exit 20


### PR DESCRIPTION
Remove a deprecated script: "RustDesk - Get RustDeskID for client". Might be a reason for why it's not removed already, but my OCD does not like to see it in Script Manager 😅 Feel free to correct me if there is a policy for leaving it as deprecated for x amount of time before removing it (it's been deprecated for approx. 1 year).